### PR TITLE
Este PR corrige a issue #6 em uma branch hotfix/v1.0.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,20 @@
 <body>
     <div id="pomodoro-container">
         <div id="timer-display">25:00</div>
+        <div id="duration-inputs">
+            <div class="duration-group">
+                <label for="pomodoro-duration">Pomodoro (min):</label>
+                <input type="number" id="pomodoro-duration" min="1" max="120" value="25">
+            </div>
+            <div class="duration-group">
+                <label for="short-break-duration">Pausa Curta (min):</label>
+                <input type="number" id="short-break-duration" min="1" max="30" value="5">
+            </div>
+            <div class="duration-group">
+                <label for="long-break-duration">Pausa Longa (min):</label>
+                <input type="number" id="long-break-duration" min="1" max="60" value="15">
+            </div>
+        </div>
         <div id="controls">
             <button id="start-btn">Iniciar</button>
             <button id="pause-btn">Pausar</button>

--- a/script.js
+++ b/script.js
@@ -1,21 +1,27 @@
-let workDuration = 25 * 60; // 25 minutos
-let breakDuration = 5 * 60; // 5 minutos
+let workDuration = 25 * 60; // 25 minutosAdd commentMore actions
+let shortBreakDuration = 5 * 60; // 5 minutos
+let longBreakDuration = 15 * 60; // 15 minutos
+let isShortBreak = true;
 let timer = workDuration;
 let isRunning = false;
 let isWorkTime = true;
 let intervalId = null;
+let pomodoroCount = 0; 
 
 // Elementos DOM
 const timerDisplay = document.getElementById('timer-display');
 const startBtn = document.getElementById('start-btn');
 const pauseBtn = document.getElementById('pause-btn');
 const resetBtn = document.getElementById('reset-btn');
+const pomodoroDurationInput = document.getElementById('pomodoro-duration');
+const shortBreakDurationInput = document.getElementById('short-break-duration');
+const longBreakDurationInput = document.getElementById('long-break-duration');
 
 function updateDisplay() {
     const minutes = String(Math.floor(timer / 60)).padStart(2, '0');
     const seconds = String(timer % 60).padStart(2, '0');
     const timeText = `${minutes}:${seconds}`;
-    
+
     timerDisplay.textContent = timeText;
     document.title = `${timeText} - ${isWorkTime ? 'Trabalho' : 'Descanso'}`;
 }
@@ -33,19 +39,97 @@ function stopTimer() {
     }
 }
 
+function getNextPhase() {
+    if (isWorkTime) {
+        // Acabou um pomodoro de trabalho
+        pomodoroCount++;
+        
+        // A cada 4 pomodoros, pausa longa
+        if (pomodoroCount % 4 === 0) {
+            return {
+                isWork: false,
+                isShort: false,
+                duration: longBreakDuration,
+                message: 'Parabéns! Você completou 4 pomodoros! Hora da pausa longa!'
+            };
+        } else {
+            return {
+                isWork: false,
+                isShort: true,
+                duration: shortBreakDuration,
+                message: `Pomodoro ${pomodoroCount} concluído! Hora da pausa curta!`
+            };
+        }
+    } else {
+        // Acabou uma pausa (curta ou longa)
+        return {
+            isWork: true,
+            isShort: false,
+            duration: workDuration,
+            message: 'Pausa terminada! Hora de trabalhar!'
+        };
+    }
+}
+
+function updateDurationsFromInputs() {
+    let newWorkDuration = parseInt(pomodoroDurationInput.value);
+    let newShortBreakDuration = parseInt(shortBreakDurationInput.value);
+    let newLongBreakDuration = parseInt(longBreakDurationInput.value);
+
+    // Garante que as durações sejam pelo menos 1
+    if (newWorkDuration < 1) {
+        newWorkDuration = 1;
+        pomodoroDurationInput.value = 1;
+    }
+    if (newShortBreakDuration < 1) {
+        newShortBreakDuration = 1;
+        shortBreakDurationInput.value = 1;
+    }
+    if (newLongBreakDuration < 1) {
+        newLongBreakDuration = 1;
+        longBreakDurationInput.value = 1;
+    }
+
+    workDuration = newWorkDuration * 60;
+    shortBreakDuration = newShortBreakDuration * 60;
+    longBreakDuration = newLongBreakDuration * 60;
+    
+    // Se o timer não estiver rodando E estiver no tempo máximo (não pausado no meio)
+    if (!isRunning) {
+        if (isWorkTime) {
+            timer = workDuration;
+        } else if (isShortBreak) {
+            timer = shortBreakDuration;
+        } else {
+            timer = longBreakDuration;
+        }
+        updateDisplay();
+    }
+}
+
 function tick() {
     if (timer > 0) {
         timer--;
         updateDisplay();
     } else {
-        stopTimer(); // Usando função reutilizada
+        stopTimer(); // Stop the current timer interval
+
+        const nextPhase = getNextPhase();
+
+        // Set the state for the upcoming phase
+        isWorkTime = nextPhase.isWork;
+        if (!isWorkTime) { // If the next phase is a break
+            isShortBreak = nextPhase.isShort; // True for short break, false for long break
+        }
         
-        isWorkTime = !isWorkTime;
-        timer = isWorkTime ? workDuration : breakDuration;
+        timer = nextPhase.duration; // Set the timer for the new phase from getNextPhase()
+
+        alert(nextPhase.message); // Announce the new phase
+
+        updateDisplay(); // Update the timer display and title
+        updateButtons(); // Ensure buttons reflect the new state (e.g., start should be enabled)
         
-        alert(isWorkTime ? 'Descanso terminado! Hora de trabalhar!' : 'Tempo de trabalho terminado! Hora do descanso!');
-        updateDisplay();
-        startTimer(); // Iniciar automaticamente próxima fase
+        startTimer();    // Automatically start the timer for the next phase
     }
 }
 
@@ -64,11 +148,13 @@ function pauseTimer() {
 
 function resetTimer() {
     stopTimer(); // Reutilizando lógica
-    
+
     // CORREÇÃO: Reset sempre volta para trabalho
     isWorkTime = true;
     timer = workDuration;
-    
+    pomodoroCount = 0; // Reset pomodoro cycle count
+    isShortBreak = true; // Reset to default break type expectation
+
     updateDisplay();
     updateButtons();
 }
@@ -77,6 +163,9 @@ function resetTimer() {
 startBtn.addEventListener('click', startTimer);
 pauseBtn.addEventListener('click', pauseTimer);
 resetBtn?.addEventListener('click', resetTimer); // Usando optional chaining
+pomodoroDurationInput.addEventListener('input', updateDurationsFromInputs);
+shortBreakDurationInput.addEventListener('input', updateDurationsFromInputs);
+longBreakDurationInput.addEventListener('input', updateDurationsFromInputs);
 
 // Inicialização
 document.addEventListener('DOMContentLoaded', () => {

--- a/style.css
+++ b/style.css
@@ -34,8 +34,8 @@ body {
 
 #duration-inputs {
     display: flex;
-    flex-direction: row;      /* Alinha horizontalmente */
-    gap: 1.5rem;              /* Espaço entre os grupos */
+    flex-direction: row;
+    gap: 1.5rem;   
     margin-bottom: 1.5rem;
     width: 100%;
     align-items: center;


### PR DESCRIPTION
Este PR corrige um problema que surgiu em produção (#6), no qual os inputs de configuração do timer não estavam sendo exibidos corretamente na interface para os usuários. 

Principais Correções
O HTML foi reestruturado para exibir corretamente os inputs de configuração da duração do timer, das pausas curtas e das pausas longas. Foi ajustada, também, a lógica do timer para garantir que somente valores positivos possam ser inseridos nos inputs.

Para Revisão
É necessário verificar se os campos dos inputs estão sendo exibidos corretamente, se estão funcionando como o esperado e se os inputs estão recebendo apenas valores positivos como entrada.